### PR TITLE
Remove broken image preload from homepage

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -3,7 +3,6 @@ import { GetServerSideProps } from 'next';
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 import Layout from '../components/Layout';
-import Head from 'next/head';
 import { fetchRandomPresident } from '../lib/presidents';
 
 interface HomePageProps {
@@ -19,13 +18,6 @@ const HomePage: React.FC<HomePageProps> = ({ randomShortName }) => {
 
     return (
         <Layout>
-            <Head>
-                <link
-                    rel="preload"
-                    href={`/images/presidents/${randomShortName}.webp`}
-                    as="image"
-                />
-            </Head>
             <p>Hotus or Notus?</p>
         </Layout>
     );


### PR DESCRIPTION
## Summary
- Removed the `<link rel="preload">` from the homepage that was downloading the full raw image file
- The preload URL (`/images/presidents/X.webp`) didn't match what Next.js Image actually requests (`/_next/image?url=...`), so it was wasted bandwidth
- The `priority` prop on the Image component already handles preloading correctly

## Test plan
- [x] Next.js build passes cleanly
- [x] Homepage still redirects to vote page correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)